### PR TITLE
feat: [POM-11451] update JavaScript SDK support as-api-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+ 
+## [2.0.0] - 2023-03-09
+### Breaking Changes
+- `postmen-api-key` is now deprecated and cannot be used for authentication. Please use this [guide](https://www.aftership.com/docs/shipping/quickstart/api-quick-start#2-get-the-api-key) to obtain the 'as-api-key' for making requests with this version. **This change does not affect the historical usage of SDK.**

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ![codecov.io](https://codecov.io/gh/postmen/postmen-sdk-js/branch/master/graphs/commits.svg)
 
 ## Introduction
-Node.js SDK for [Postmen API](https://docs.postmen.com/).
+Node.js SDK for [Postmen API](https://www.aftership.com/docs/shipping/quickstart/api-quick-start).
 For problems and suggestions please open [GitHub issue](https://github.com/postmen/postmen-sdk-js/issues)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -50,7 +50,7 @@ npm install postmen
 
 ## Quick Start
 
-In order to get API key and choose a region refer to the [documentation](https://docs.postmen.com/overview.html).
+In order to get API key refer to the [documentation](https://www.aftership.com/docs/shipping/quickstart/api-quick-start#2-get-the-api-key).
 
 ```javascript
 'use strict';

--- a/examples/labels_create.js
+++ b/examples/labels_create.js
@@ -99,7 +99,7 @@ let config = {};
 
 // create labels with input and config
 postmen.create('/labels', input, config).then(function (result) {
-	console.log('ERROR:', result);
+	console.log('RESULT:', result);
 }).catch(function (err) {
-	console.log('RESULT:', err);
+	console.log('ERROR:', err);
 });

--- a/examples/manifests_create.js
+++ b/examples/manifests_create.js
@@ -22,7 +22,7 @@ let config = {
 };
 
 postmen.create('/manifests', input, config).then(function (result) {
-	console.log('ERROR:', result);
+	console.log('RESULT:', result);
 }).catch(function (err) {
-	console.log('RESULT:', err);
+	console.log('ERROR:', err);
 });

--- a/examples/rates_create.js
+++ b/examples/rates_create.js
@@ -79,7 +79,7 @@ let config = {};
 
 // create rates with input and config
 postmen.create('/rates', input, config).then(function (result) {
-	console.log('ERROR:', result);
+	console.log('RESULT:', result);
 }).catch(function (err) {
-	console.log('RESULT:', err);
+	console.log('ERROR:', err);
 });

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -20,7 +20,7 @@ class Handler {
 	 * @param callback {function}
 	 */
 	static handlePayload(postmen, payload, callback) {
-		let ratelimit = _.get(postmen.rate_limit, _.get(payload.request_object.headers, 'postmen-api-key'));
+		let ratelimit = _.get(postmen.rate_limit, _.get(payload.request_object.headers, 'as-api-key'));
 		if (ratelimit && ratelimit.remaining <= 0) {
 			Handler._retryTooManyRequestError(postmen, payload, null, callback);
 		} else {
@@ -36,7 +36,7 @@ class Handler {
 	 */
 	static _makeRequest(postmen, payload, callback) {
 		// console.log(payload);
-		// use existing postmen.rate_limit[payload.request_object.headers['postmen-api-key']]
+		// use existing postmen.rate_limit[payload.request_object.headers['as-api-key']]
 		postmen.request(payload.request_object, function (err, req, body) {
 			if (err) {
 				// If request return err
@@ -50,7 +50,7 @@ class Handler {
 				return;
 			}
 			// If no err, set rate_limit
-			postmen.rate_limit[_.get(payload.request_object.headers, 'postmen-api-key')] = {
+			postmen.rate_limit[_.get(payload.request_object.headers, 'as-api-key')] = {
 				limit: Number(_.get(req.headers, 'x-ratelimit-limit')),
 				remaining: Number(_.get(req.headers, 'x-ratelimit-remaining')),
 				reset: Number(_.get(req.headers, 'x-ratelimit-reset'))
@@ -112,7 +112,7 @@ class Handler {
 	 */
 	static _retryTooManyRequestError(postmen, payload, body, callback) {
 		if (postmen.rate) {
-			let timeout = postmen.rate_limit[payload.request_object.headers['postmen-api-key']].reset - Date.now();
+			let timeout = postmen.rate_limit[payload.request_object.headers['as-api-key']].reset - Date.now();
 			// Retry after timeout
 			setTimeout(function () {
 				Handler._makeRequest(postmen, payload, callback);

--- a/lib/payload.js
+++ b/lib/payload.js
@@ -47,7 +47,7 @@ class Payload {
 		// Request object
 		let request_object = {
 			headers: Object.assign({
-				'postmen-api-key': config.api_key || postmen.tmp_api_key || postmen.api_key,
+				'as-api-key': config.api_key || postmen.tmp_api_key || postmen.api_key,
 				'Content-Type': 'application/json',
 				'Connection': 'keep-alive',
 				'x-postmen-agent': version

--- a/lib/postmen.js
+++ b/lib/postmen.js
@@ -33,7 +33,7 @@ class Postmen {
 		this.request = request;
 		this.tmp_api_key = null;
 		this.api_key = api_key;
-		this.endpoint = config.endpoint || 'https://' + region + '-api.postmen.com/v3';
+		this.endpoint = config.endpoint || 'https://' + region + '-api.aftership.com/postmen/v3';
 		this.proxy = config.proxy || null;
 		this.retry = _.isBoolean(config.retry) ? config.retry : true;
 		this.rate = _.isBoolean(config.rate) ? config.rate : true;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postmen",
   "description": "Postmen SDK for JavaScript in the browser and Node.js",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "homepage": "https://github.com/Postmen/sdk-js",
   "author": {
     "name": "Postmen",

--- a/test/test_hanlder.js
+++ b/test/test_hanlder.js
@@ -12,7 +12,7 @@ const Handler = require('./../lib/handler');
 
 const api_key = 'FAKE_API_KEY';
 const region = 'FAKE_REGION';
-const default_endpoint = 'https://FAKE_REGION-api.postmen.com/v3';
+const default_endpoint = 'https://FAKE_REGION-api.aftership.com/postmen/v3';
 
 describe('Test postmen.call()', function () {
 	this.timeout(600000);
@@ -205,7 +205,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -224,7 +224,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -245,7 +245,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -270,7 +270,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0',
 						'platform': 'csv'
@@ -293,7 +293,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -318,7 +318,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -342,7 +342,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -363,7 +363,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -413,7 +413,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -432,7 +432,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -451,7 +451,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -470,7 +470,7 @@ describe('Test postmen.call()', function () {
 				let request_object = {
 					headers: {
 						'Connection': 'keep-alive',
-						'postmen-api-key': api_key,
+						'as-api-key': api_key,
 						'Content-Type': 'application/json',
 						'x-postmen-agent': '1.0.0'
 					},
@@ -714,7 +714,7 @@ describe('Test postmen.call()', function () {
 				let payload = {
 					request_object: {
 						headers: {
-							'postmen-api-key': 'FAKE_API_KEY'
+							'as-api-key': 'FAKE_API_KEY'
 						}
 					}
 				};
@@ -735,12 +735,12 @@ describe('Test postmen.call()', function () {
 			let payload = {
 				request_object: {
 					headers: {
-						'postmen-api-key': 'FAKE_API_KEY',
+						'as-api-key': 'FAKE_API_KEY',
 						'Content-Type': 'application/json',
 						Connection: 'keep-alive',
 						'x-postmen-agent': '1.0.0'
 					},
-					url: 'https://FAKE_REGION-api.postmen.com/v3/labels',
+					url: 'https://FAKE_REGION-api.aftership.com/postmen/v3/labels',
 					method: 'GET',
 					json: true
 				},
@@ -813,12 +813,12 @@ describe('Test postmen.call()', function () {
 				payload = {
 					request_object: {
 						headers: {
-							'postmen-api-key': 'FAKE_API_KEY',
+							'as-api-key': 'FAKE_API_KEY',
 							'Content-Type': 'application/json',
 							Connection: 'keep-alive',
 							'x-postmen-agent': '1.0.0'
 						},
-						url: 'https://FAKE_REGION-api.postmen.com/v3/labels',
+						url: 'https://FAKE_REGION-api.aftership.com/postmen/v3/labels',
 						method: 'GET',
 						json: true
 					},
@@ -857,12 +857,12 @@ describe('Test postmen.call()', function () {
 			let payload = {
 				request_object: {
 					headers: {
-						'postmen-api-key': 'FAKE_API_KEY',
+						'as-api-key': 'FAKE_API_KEY',
 						'Content-Type': 'application/json',
 						Connection: 'keep-alive',
 						'x-postmen-agent': '1.0.0'
 					},
-					url: 'https://FAKE_REGION-api.postmen.com/v3/labels',
+					url: 'https://FAKE_REGION-api.aftership.com/postmen/v3/labels',
 					method: 'GET',
 					json: true
 				},

--- a/test/test_payload.js
+++ b/test/test_payload.js
@@ -289,7 +289,7 @@ describe('Test Payload constructor', function () {
 				let result = Payload(postmen, 'GET', '');
 				let headers = {
 					'Connection': 'keep-alive',
-					'postmen-api-key': api_key,
+					'as-api-key': api_key,
 					'Content-Type': 'application/json',
 					'x-postmen-agent': '1.0.0'
 				};
@@ -407,7 +407,7 @@ describe('Test Payload constructor', function () {
 				let result = Payload(postmen, 'GET', '', {
 					api_key: other_api_key
 				});
-				expect(result.request_object.headers['postmen-api-key']).to.equal(other_api_key);
+				expect(result.request_object.headers['as-api-key']).to.equal(other_api_key);
 			});
 		});
 
@@ -437,7 +437,7 @@ describe('Test Payload constructor', function () {
 
 			it('should set correct api_key', function (done) {
 				postmen.useApiKey('OTHER_FAKE_API_KEY').get('labels', function (err, result) {
-					expect(postmen.request.args[0][0].headers['postmen-api-key']).equal('OTHER_FAKE_API_KEY');
+					expect(postmen.request.args[0][0].headers['as-api-key']).equal('OTHER_FAKE_API_KEY');
 					done();
 				});
 			});

--- a/test/test_postmen.js
+++ b/test/test_postmen.js
@@ -8,7 +8,7 @@ const Postmen = require('./../index');
 
 let api_key = 'FAKE_API_KEY';
 let region = 'FAKE_REGION';
-let default_endpoint = 'https://FAKE_REGION-api.postmen.com/v3';
+let default_endpoint = 'https://FAKE_REGION-api.aftership.com/postmen/v3';
 let default_proxy = null;
 let default_retry = true;
 
@@ -29,7 +29,7 @@ describe('Test constructor', function () {
 		});
 
 		it('should construct with api_key and region correctly', function () {
-			let endpoint = 'https://awesome-api.postmen.com/v3';
+			let endpoint = 'https://awesome-api.aftership.com/postmen/v3';
 			let postmen = Postmen(api_key, 'awesome');
 			expect(postmen.api_key).to.equal(api_key);
 			expect(postmen.endpoint).to.equal(endpoint);
@@ -38,7 +38,7 @@ describe('Test constructor', function () {
 		});
 
 		it('should construct with api_key and endpoint correctly', function () {
-			let endpoint = 'https://awesome-api.postmen.com/v3';
+			let endpoint = 'https://awesome-api.aftership.com/postmen/v3';
 			let postmen = Postmen(api_key, region, {
 				endpoint: endpoint
 			});


### PR DESCRIPTION
2.0.0
升级 SDK，使用 as-api-key 进行鉴权。
<img width="529" alt="image" src="https://user-images.githubusercontent.com/84337467/223954579-4b622ddb-62e1-4de3-91f6-7684ed5ae2d1.png">
